### PR TITLE
Switch coverage report provide to codecov.io

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,6 @@ environment:
         - PYTHON: Python36
         - PYTHON: Python37
         - PYTHON: Python38
-        - PYTHON: Python39
 
 install:
     - C:\%PYTHON%\python.exe -m pip install .

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,6 @@
-name: Codacy coverage report
+name: Coverage report
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -23,13 +23,17 @@ jobs:
     - name: Generate coverage report
       run: |
         coverage erase
-        pytest --cov=codemetrics --cov-branch --cov-report=term-missing:skip-covered --cov-config=setup.cfg
+        pytest --cov=codemetrics --cov-branch --cov-report=xml --cov-config=setup.cfg
         coverage xml
-    - name: Codacy Coverage Reporter
-      uses: codacy/codacy-coverage-reporter-action@master
+    - name: "Upload coverage to Codecov"
+      uses: codecov/codecov-action@v1
       with:
-        project-token: ${{secrets.CODACY_PROJECT_TOKEN}}
-        coverage-reports: coverage.xml
+        fail_ci_if_error: true
+# Codacy does not seem to support coverage.xml out of the box
+#   - name: Codacy Coverage Reporter
+#     uses: codacy/codacy-coverage-reporter-action@master
+#     with:
+#       project-token: ${{secrets.CODACY_PROJECT_TOKEN}}
 
 
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -3,11 +3,7 @@
 
 name: Python application
 
-on:
-  push:
-    branches: [master,develop]
-  pull_request:
-    branches: [master,develop]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,8 @@
     :target: https://codemetrics.readthedocs.org/
     :alt: Documentation
 
-.. image:: https://coveralls.io/repos/elmotec/codemetrics/badge.svg
-    :target: https://coveralls.io/r/elmotec/codemetrics
+.. image:: https://codecov.io/gh/elmotec/codemetrics/branch/master/graph/badge.svg?token=ELJW941FET
+    :target: https://codecov.io/gh/elmotec/codemetrics
     :alt: Coverage
 
 .. image:: https://img.shields.io/codacy/grade/dd4a11eb66674b3bbe518d8f829b6234.svg


### PR DESCRIPTION
- Leverages github actions for PRs and branches.
- Ignore codacy coverage for now because it does not seem to handle
Python coverage report coverage.xml.

Also:
- Removed 3.9 from appveyor because it is not found.
- Changed badge to reflect provider switch.