### PR TITLE
ci(commitizen): add commitizen

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,17 +1,21 @@
+# Do not build branch with open PR
+skip_branch_with_pr: true
+
 image:
-  - Visual Studio 2019
+- Visual Studio 2019
 
 environment:
-    matrix:
-        - PYTHON: Python37-x64
-        - PYTHON: Python38-x64
-        - PYTHON: Python39-x64
-        - PYTHON: Python310-x64
+  matrix:
+  - PYTHON: Python37-x64
+  - PYTHON: Python38-x64
+  - PYTHON: Python39-x64
+  - PYTHON: Python310-x64
 
 install:
-    - C:\%PYTHON%\python.exe -m pip install .
+- C:\%PYTHON%\python.exe -m pip install pip --upgrade
+- C:\%PYTHON%\python.exe -m pip install . pytest
 
 build: off
 
 test_script:
-    - C:\%PYTHON%\python.exe setup.py test
+- C:\%PYTHON%\python.exe -m pytest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
         coverage erase
         pytest --cov=codemetrics --cov-branch --cov-report=xml --cov-config=setup.cfg
         coverage xml
-    - name: "Upload coverage to Codecov"
+    - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
         fail_ci_if_error: true

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -3,7 +3,7 @@
 
 name: Python application
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7","3.8","3.9","3.10"]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,31 +1,50 @@
+default_stages: [commit]
 repos:
--   repo: https://github.com/python/black
-    rev: 22.1.0
-    hooks:
-    -   id: black
-        language_version: python3.8
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
-    hooks:
-    -   id: flake8
-        language: python_venv
-        additional_dependencies: [flake8-comprehensions>=3.1.0]
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.941
-    hooks:
-    -   id: mypy
-        args: ['--install-types', '--non-interactive', '--ignore-missing-import']
-        files: codemetrics/
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
-    hooks:
-    -   id: isort
+- repo: https://github.com/commitizen-tools/commitizen
+  rev: v2.21.2
+  hooks:
+  - id: commitizen
+    stages: [commit-msg]
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.1.0    # Use the ref you want to point at
+  hooks:
+  - id: check-added-large-files
+  - id: check-merge-conflict
+  - id: debug-statements
+  - id: detect-private-key
+  - id: requirements-txt-fixer
+- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+  rev: v2.2.0
+  hooks:
+  - id: pretty-format-yaml
+    args: [--autofix, --indent, '2']
+- repo: https://github.com/python/black
+  rev: 22.1.0
+  hooks:
+  - id: black
+    language_version: python3.8
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.9.2
+  hooks:
+  - id: flake8
+    language: python_venv
+    additional_dependencies: [flake8-comprehensions>=3.1.0]
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.941
+  hooks:
+  - id: mypy
+    args: [--install-types, --non-interactive, --ignore-missing-import]
+    files: codemetrics/
+- repo: https://github.com/pre-commit/mirrors-isort
+  rev: v5.10.1
+  hooks:
+  - id: isort
 - repo: local
   hooks:
   # will use local pylintrc and know about local libs in venv
   - id: tests
-    name: test
+    name: tests
     entry: python -m unittest
     language: system
     pass_filenames: false
-    always_run: true
+    always_run: false

--- a/codemetrics/git.py
+++ b/codemetrics/git.py
@@ -217,10 +217,10 @@ class _GitLogCollector(scm.ScmLogCollector):
         if before:
             command += ["--before", f"{before:%Y-%m-%d}"]
         command.append(path)
-        if self._pdb:
-            import pdb
-
-            pdb.set_trace()
+        # For debugging
+        # if self._pdb:
+        #     import pdb
+        #     pdb.set_trace()
         results = internals.run(command, cwd=self.cwd).split("\n")
         return self.process_log_output_to_df(
             results, after=after, progress_bar=progress_bar

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 Sphinx
-sphinx_rtd_theme
 sphinx-autodoc-typehints
+sphinx_rtd_theme

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -21,6 +21,6 @@ sphinx:
 python:
   version: 3.7
   install:
-    - requirements: docs/requirements.txt
-    - method: pip
-      path: .
+  - requirements: docs/requirements.txt
+  - method: pip
+    path: .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 black[d]
-bump2version
+commitizen
 coverage
 flake8
 pip


### PR DESCRIPTION
Replace bump2version with commitizen which is has more features. Also replace
tests with pytest in appveyor.yml that was giving warnings about setup.py
test, and prevent appveyor from building branches with PRs. Format yaml and
requirements files adding new pre-commit hooks.