### PR TITLE
fix: fix lizard removing length

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     stages:
     - commit-msg
   repo: https://github.com/commitizen-tools/commitizen
-  rev: v2.21.2
+  rev: v2.24.0
 - hooks:
   - id: check-added-large-files
   - id: check-merge-conflict
@@ -14,7 +14,7 @@ repos:
   - id: detect-private-key
   - id: requirements-txt-fixer
   repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.1.0
+  rev: v4.2.0
 - hooks:
   - args:
     - --autofix
@@ -27,7 +27,7 @@ repos:
   - id: black
     language_version: python3.8
   repo: https://github.com/python/black
-  rev: 22.1.0
+  rev: 22.3.0
 - hooks:
   - additional_dependencies:
     - flake8-comprehensions>=3.1.0
@@ -43,7 +43,7 @@ repos:
     files: codemetrics/
     id: mypy
   repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.941
+  rev: v0.942
 - hooks:
   - id: isort
   repo: https://github.com/pre-commit/mirrors-isort

--- a/codemetrics/scm.py
+++ b/codemetrics/scm.py
@@ -24,7 +24,7 @@ ChunkStats = collections.namedtuple(
 )
 
 
-class Project(abc.ABC):
+class Project:
     """Stores context information about the SCM tree.
 
     At first the attributes are initialized to None until the first request to the SCM tool.
@@ -45,11 +45,9 @@ class Project(abc.ABC):
         """
         self.cwd = cwd
 
-    @abc.abstractmethod
-    def download(self, data: pd.DataFrame) -> DownloadResult:
-        pass
+    def download(self, data: pd.DataFrame) -> typing.Optional[DownloadResult]:
+        return None
 
-    @abc.abstractmethod
     def get_log(
         self,
         path: str = ".",
@@ -60,7 +58,7 @@ class Project(abc.ABC):
         relative_url: str = None,
         _pdb=False,
     ) -> pd.DataFrame:
-        pass
+        return pd.DataFrame(columns=LogEntry.__slots__)
 
 
 def get_log(project: Project, *args, **kwargs) -> pd.DataFrame:

--- a/tests/test_cloc.py
+++ b/tests/test_cloc.py
@@ -12,6 +12,7 @@ from unittest import mock
 import pandas as pd
 
 import codemetrics.cloc as loc
+import codemetrics.scm as scm
 
 from . import utils
 
@@ -45,7 +46,7 @@ class SimpleDirectory(unittest.TestCase):
 
     def test_cloc_reads_files(self):
         """cloc is called and reads the output csv file."""
-        actual = loc.get_cloc(utils.FakeProject())
+        actual = loc.get_cloc(scm.Project())
         self.run_.assert_called_with("cloc --csv --by-file .".split(), cwd=pl.Path("."))
         expected = pd.read_csv(
             io.StringIO(
@@ -67,7 +68,7 @@ class SimpleDirectory(unittest.TestCase):
         """Clean error message when cloc is not found in the path."""
         self.run_.side_effect = [FileNotFoundError]
         with self.assertRaises(FileNotFoundError) as context:
-            _ = loc.get_cloc(utils.FakeProject())
+            _ = loc.get_cloc(scm.Project())
         self.assertIn("cloc", str(context.exception))
 
 
@@ -78,7 +79,7 @@ class TestClocCall(unittest.TestCase):
     def test_cloc_fails_if_not_in_root(self, path_glob):
         """Make sure that command line call checks it is run from the root."""
         with self.assertRaises(ValueError) as context:
-            loc.get_cloc(utils.FakeProject())
+            loc.get_cloc(scm.Project())
         path_glob.assert_called_with(mock.ANY, pattern=".svn")
         self.assertIn("git or svn root", str(context.exception))
 
@@ -86,7 +87,7 @@ class TestClocCall(unittest.TestCase):
     @mock.patch("codemetrics.internals.run", autospec=True)
     def test_cloc_called_with_path(self, run, _):
         """Make sure the path is passed as argument to cloc when passed to the function."""
-        loc.get_cloc(utils.FakeProject(), path="some-path")
+        loc.get_cloc(scm.Project(), path="some-path")
         run.assert_called_with(
             ["cloc", "--csv", "--by-file", "some-path"], cwd=pl.Path(".")
         )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -422,10 +422,10 @@ class GetComplexityTestCase(utils.DataFrameTestCase):
             io.StringIO(
                 textwrap.dedent(
                     """\
-        revision,path,function,cyclomatic_complexity,nloc,token_count,name,long_name,start_line,end_line,top_nesting_level,length,fan_in,fan_out,general_fan_out,file_tokens,file_nloc
-        r1,f.py,0,2,4,16,test,test( ),1,4,0,4,0,0,0,17,4
-        r2,f.py,0,1,2,8,test,test( ),1,2,0,2,0,0,0,18,4
-        r2,f.py,1,1,2,8,other,other( ),4,5,0,2,0,0,0,18,4
+        revision,path,function,cyclomatic_complexity,nloc,token_count,name,long_name,start_line,end_line,top_nesting_level,fan_in,fan_out,general_fan_out,file_tokens,file_nloc,length
+        r1,f.py,0,2,4,16,test,test( ),1,4,0,0,0,0,17,4,4
+        r2,f.py,0,1,2,8,test,test( ),1,2,0,0,0,0,18,4,2
+        r2,f.py,1,1,2,8,other,other( ),4,5,0,0,0,0,18,4,2
         """
                 )
             ),
@@ -434,9 +434,9 @@ class GetComplexityTestCase(utils.DataFrameTestCase):
 
     def get_complexity(self):
         """Factor retrieval of complexity"""
-        project = utils.FakeProject()
+        project = scm.Project()
         with mock.patch.object(
-            utils.FakeProject,
+            scm.Project,
             "download",
             autospec=True,
             side_effect=[
@@ -467,11 +467,11 @@ class GetComplexityTestCase(utils.DataFrameTestCase):
         columns = (
             "function".split()
             + cm.core._lizard_fields
-            + "file_tokens file_nloc".split()
+            + "file_tokens file_nloc length".split()
         )
-        project = utils.FakeProject()
+        project = scm.Project()
         with mock.patch.object(
-            utils.FakeProject,
+            scm.Project,
             "download",
             autospec=True,
             return_value=scm.DownloadResult(1, "f.py", ""),
@@ -489,15 +489,15 @@ class GetComplexityTestCase(utils.DataFrameTestCase):
     def test_analysis_empty_input_return_empty_output(self, _):
         """Empty input returns and empty dataframe."""
         self.log = self.log.iloc[:0]
-        actual = cm.get_complexity(self.log, utils.FakeProject())
+        actual = cm.get_complexity(self.log, scm.Project())
         self.assertEqual(list(actual.columns), list(self.expected.columns))
         self.assertEqual(len(actual), 0)
 
     def test_use_default_download(self):
         """When the context.downlad_funcc is defined, use it."""
-        project = utils.FakeProject()
+        project = scm.Project()
         with mock.patch.object(
-            utils.FakeProject, "download", return_value=scm.DownloadResult(1, "/", "")
+            scm.Project, "download", return_value=scm.DownloadResult(1, "/", "")
         ) as download:
             _ = cm.get_complexity(self.log, project)
             download.assert_called_with(self.log)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -195,6 +195,13 @@ class HotSpotReportTestCase(SimpleRepositoryFixture):
         actual = cm.get_hot_spots(log, self.loc)
         self.assertEqual(self.expected, actual)
 
+    def test_hot_spot_report_by_path(self):
+        """Generate a report to find hot spots with path passed explicitely."""
+        after = dt.datetime(2018, 2, 26, tzinfo=dt.timezone.utc)
+        log = self.log.loc[self.log["date"] >= after, :]
+        actual = cm.get_hot_spots(log, self.loc, by="path")
+        self.assertEqual(self.expected, actual)
+
     def test_hot_spot_with_custom_change_metric(self):
         """Generate report with a different change metric than revision.
 
@@ -241,6 +248,23 @@ class CoChangeTestCase(SimpleRepositoryFixture):
     def test_co_change_report(self):
         """Simple CoChangeReport usage."""
         actual = cm.get_co_changes(log=SimpleRepositoryFixture.get_log_df())
+        expected = pd.read_csv(
+            io.StringIO(
+                textwrap.dedent(
+                    """
+        path,dependency,changes,cochanges,coupling
+        requirements.txt,stats.py,1,1,1.0
+        stats.py,requirements.txt,2,1,0.5
+        """
+                )
+            ),
+            dtype={"path": "string", "dependency": "string"},
+        )
+        self.assertEqual(expected, actual)
+
+    def test_co_change_report_by_path(self):
+        """Simple CoChangeReport usage with path passed explicitely."""
+        actual = cm.get_co_changes(log=SimpleRepositoryFixture.get_log_df(), by="path")
         expected = pd.read_csv(
             io.StringIO(
                 textwrap.dedent(

--- a/tests/test_scm.py
+++ b/tests/test_scm.py
@@ -136,6 +136,7 @@ class TestLogEntriesToDataFrame(unittest.TestCase):
         self.assertEqual("float32", self.dtypes["removed"].name)
 
 
+# pylint: disable=no-member
 class CommonProjectTestCase:
     """Test GitProject functionalities common to all projects.
 
@@ -154,7 +155,7 @@ class CommonProjectTestCase:
     @mock.patch(
         "codemetrics.internals.run", autospec=True, return_value="dummy content"
     )
-    def test_download_return_single_result(self, _):
+    def test_download_return_single_result_or_none(self, _):
         """Makes sure the download function returns a DownloadResult."""
         project = self.Project()
         actual = project.download(
@@ -181,6 +182,28 @@ class CommonProjectTestCase:
         ) as get_log_method:
             cm.get_log(project)
             get_log_method.assert_called_with(project)
+
+
+class BaseProjectTestCase(unittest.TestCase):
+    """"Special use case tied to scm.Project
+
+    scm.Project is used as a base class for Git and SVN project and in tests.
+
+    """ ""
+
+    def setUp(self):
+        self.project = scm.Project()
+
+    def test_project_get_log_returns_expected_columns(self):
+        """scm.Project.get_log() method returns a pd.DataFrame with the right columns."""
+        actual = cm.get_log(scm.Project("."))
+        self.assertIsInstance(actual, pd.DataFrame)
+        self.assertEqual(actual.columns.tolist(), scm.LogEntry.__slots__)
+
+    def test_project_download_returns_none(self):
+        """scm.Project download() method returns None."""
+        download_result = scm.Project(".").download(pd.DataFrame())
+        self.assertIsNone(download_result)
 
 
 class GetLogTestCase:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -94,13 +94,3 @@ def csvlog_to_dataframe(csv_log: str) -> pd.DataFrame:
     # Reorder columns.
     df = df[scm.LogEntry.__slots__].pipe(scm.normalize_log)
     return df
-
-
-class FakeProject(scm.Project):
-    """Fake project with pre-determined values for the download return values."""
-
-    def download(self, data: pd.DataFrame) -> scm.DownloadResult:
-        pass
-
-    def get_log(self, **kwargs) -> pd.DataFrame:
-        pass


### PR DESCRIPTION
Generate function length on the fly for now. Unfortunately the length
column is now at the end but that should not have big impact. Also
replaced FakeProject with the default scm.Project, updated pre-commit
dependencies.