### PR TITLE
ci: add deps version in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
 	tqdm>=4
 	python-dateutil>=2
 	scikit-learn>=1,<2
-	lizard==1.17
+	lizard>1.17
 	mypy-extensions
 include_package_data = True,
 packages = codemetrics

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,13 +32,13 @@ classifiers =
 setup_requires =
 	wheel
 install_requires =
-	numpy
-	click>=6.0
-	pandas
-	tqdm
-	python-dateutil
-	scikit-learn
-	lizard
+	numpy>=1,<2
+	click>=6
+	pandas>=1<2
+	tqdm>=4
+	python-dateutil>=2
+	scikit-learn>=1,<2
+	lizard==1.17
 	mypy-extensions
 include_package_data = True,
 packages = codemetrics

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -514,7 +514,8 @@ class GetComplexityTestCase(utils.DataFrameTestCase):
         """Empty input returns and empty dataframe."""
         self.log = self.log.iloc[:0]
         actual = cm.get_complexity(self.log, scm.Project())
-        self.assertEqual(list(actual.columns), list(self.expected.columns))
+        # Length may be at the end or in the middle dependeding on the version of lizard.
+        self.assertEqual(sorted(actual.columns), sorted(self.expected.columns))
         self.assertEqual(len(actual), 0)
 
     def test_use_default_download(self):


### PR DESCRIPTION
Also relax the order of columns in test_analysis_empty_input_return_empty_output so it 
would pass independently of the version of Lizard.